### PR TITLE
fix: share event always well-formed

### DIFF
--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -121,11 +121,8 @@ any tabs.
 ### serviceworker.js
 
 ```js
-navigator.actions.addEventListener('share', event => {
-  if (event.data.url === undefined)
-    throw new Error('Did not contain URL.');
-
-  includinate(event.data.url);
+addEventListener('share', event => {
+  includinate(event.url);
 });
 ```
 


### PR DESCRIPTION
It should be an invariant that share event always have a valid URLs. 

Also, the eventListener() would just be on `GlobalWorkerScope` - it's defined as so in the interface object.