### PR TITLE
Define and use reserved percent-encode set

### DIFF
--- a/index.html
+++ b/index.html
@@ -451,9 +451,8 @@ partial dictionary WebAppManifest {
         <p>
           The <dfn>reserved percent-encode set</dfn> is the <a data-cite=
           "!URL#userinfo-percent-encode-set">userinfo percent-encode set</a>
-          and U+0021 (!), U+0024 ($), U+0025 (%), U+0026 (&amp;), U+0027 ('),
-          U+0028 LEFT PARENTHESIS, U+0029 RIGHT PARENTHESIS, U+002A (*), U+002B
-          (+), and U+002C (,).
+          and U+0024 ($), U+0025 (%), U+0026 (&amp;), U+002B (+), and U+002C
+          (,).
         </p>
         <p class="note">
           The <a>reserved percent-encode set</a> is the complement of the

--- a/index.html
+++ b/index.html
@@ -413,9 +413,8 @@ partial dictionary WebAppManifest {
               </li>
               <li>Replace each character of <var>value</var>, <var>c</var>,
               with the result of <a data-cite="!URL#utf-8-percent-encode">UTF-8
-              percent encoding</a> <var>c</var> using the <a data-cite=
-              "!URL#userinfo-percent-encode-set">userinfo percent-encode
-              set</a>.
+              percent encoding</a> <var>c</var> using the <a>reserved
+              percent-encode set</a>.
               </li>
               <li>Replace the characters in <var>template</var> from indices
               <var>start</var> to <var>end</var>, inclusive, with
@@ -449,6 +448,24 @@ partial dictionary WebAppManifest {
           </p>
         </div>
         <div class="issue" data-number="25"></div>
+        <p>
+          The <dfn>reserved percent-encode set</dfn> is the <a data-cite=
+          "!URL#userinfo-percent-encode-set">userinfo percent-encode set</a>
+          and U+0021 (!), U+0024 ($), U+0025 (%), U+0026 (&amp;), U+0027 ('),
+          U+0028 LEFT PARENTHESIS, U+0029 RIGHT PARENTHESIS, U+002A (*), U+002B
+          (+), and U+002C (,).
+        </p>
+        <p class="note">
+          The <a>reserved percent-encode set</a> is the complement of the
+          "unreserved" set in [[rfc2396]], the same set used by <a data-cite=
+          "ECMAScript#sec-encodeuricomponent-uricomponent">encodeURIComponent</a>
+          from [[ECMAScript]].
+        </p>
+        <p class="issue">
+          The <a>reserved percent-encode set</a> should be defined in [[!URL]],
+          not here. See <a href=
+          "https://github.com/whatwg/url/issues/369">whatwg/url#369</a>.
+        </p>
       </section>
     </section>
     <section class="informative">


### PR DESCRIPTION
This fixes the set of characters that are encoded when substituting into a placeholder, to include all the "reserved" and illegal characters from RFC 2396 (matching the behaviour of encodeURIComponent).

There is no appropriate set to use in the URL Standard. whatwg/url#369 discusses adding this (also needed for properly specifying registerProtocolHandler), but for now, I'm just putting it in the Web Share Target spec.

Closes #9.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/web-share-target/pull/32.html" title="Last updated on Feb 16, 2018, 6:04 AM GMT (55f95c8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-share-target/32/9f5db53...mgiuca:55f95c8.html" title="Last updated on Feb 16, 2018, 6:04 AM GMT (55f95c8)">Diff</a>