### PR TITLE
Validate that key is a WebIDL identifier

### DIFF
--- a/index.html
+++ b/index.html
@@ -403,6 +403,10 @@ partial dictionary WebAppManifest {
               in between indices <var>start</var> and <var>end</var>,
               exclusive.
               </li>
+              <li>If <var>key</var> is not a valid
+              <a data-cite="!WEBIDL#prod-identifier">WebIDL identifier</a>,
+              return failure (invalid key).
+              </li>
               <li>Let <var>value</var> be <var>data</var>[<var>key</var>] (this
               is always a <a data-cite="!WEBIDL#idl-USVString">USVString</a>).
               If it is undefined, let <var>value</var> be the empty string.


### PR DESCRIPTION
In the replace placeholders algorithm, we now validate that
the key is a valid WebIDL identifier.

resolves #35


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ewilligers/web-share-target/pull/36.html" title="Last updated on Feb 16, 2018, 5:32 AM GMT (a79869d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-share-target/36/4ae1bcd...ewilligers:a79869d.html" title="Last updated on Feb 16, 2018, 5:32 AM GMT (a79869d)">Diff</a>