### PR TITLE
Updated Share Target demo to new API.

### DIFF
--- a/demos/manifest.json
+++ b/demos/manifest.json
@@ -4,7 +4,13 @@
   "start_url": "sharetarget.html",
   "display": "standalone",
   "share_target": {
-    "url_template": "sharetarget.html?title={title}&text={text}&url={url}"
+    "url_template": "sharetarget.html?oldapi=true&title={title}&text={text}&url={url}",
+    "action": "sharetarget.html",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url"
+    }
   },
   "icons": [{
     "src": "images/icon-16.png",

--- a/demos/sharetarget.html
+++ b/demos/sharetarget.html
@@ -75,6 +75,13 @@
       logText("Title shared: " + parsedUrl.searchParams.get("title"));
       logText("Text shared: " + parsedUrl.searchParams.get("text"));
       logText("URL shared: " + parsedUrl.searchParams.get("url"));
+      // We still have the old "url_template" member in the manifest, which is
+      // how WST was previously specced and implemented in Chrome. If the user
+      // agent uses that method, the "oldapi" parameter will be set.
+      if (parsedUrl.searchParams.get("oldapi")) {
+        logText("Your browser is using the deprecated 'url_template' Web Share "
+                + "Target API.", true);
+      }
     }
 
     window.addEventListener('load', onLoad);


### PR DESCRIPTION
Still uses `url_template` for backwards compatibility, setting a flag and showing some UI to indicate that the user agent is still using the old API.