### PR TITLE
Omit any field that is not present in ShareData.

### DIFF
--- a/index.html
+++ b/index.html
@@ -474,8 +474,7 @@ partial dictionary WebAppManifest {
               <li>Let <var>value</var> be the value of
               <var>data</var>[<var>member</var>].
               </li>
-              <li>If <var>value</var> is <code>undefined</code>, set
-              <var>value</var> to an empty string.
+              <li>If <var>value</var> is <code>undefined</code>, then continue.
               </li>
               <li>
                 <a data-cite="!INFRA#list-append">Append</a> to <var>entry


### PR DESCRIPTION
No longer creates a "key=" parameter (with an empty value) if the field
is missing in the shared data.

Closes #45.