### PR TITLE
Use window.location rather than window.location.toString()

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
   &lt;body&gt;
     &lt;script&gt;
       window.addEventListener('load', () =&gt; {
-        var parsedUrl = new URL(window.location.toString());
+        var parsedUrl = new URL(window.location);
         console.log('Title shared: ' + parsedUrl.searchParams.get('name'));
         console.log('Text shared: ' + parsedUrl.searchParams.get('description'));
         console.log('URL shared: ' + parsedUrl.searchParams.get('link'));


### PR DESCRIPTION
`window.location` is simpler, and works fine given the `stringifier` on the `Location` interface.  This makes the example slightly simpler.

I got here from w3ctag/design-reviews#221.