### PR TITLE
Fix swapped definitions of title and text members.

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,12 +311,12 @@ partial dictionary WebAppManifest {
         </p>
         <p>
           The <dfn>title</dfn> member specifies the name of the query parameter
-          used for the arbitrary text that forms the body of the message being
-          shared.
+          used for the title of the document being shared.
         </p>
         <p>
           The <dfn>text</dfn> member specifies the name of the query parameter
-          used for the title of the document being shared.
+          used for the arbitrary text that forms the body of the message being
+          shared.
         </p>
         <p>
           The <dfn>url</dfn> member specifies the name of the query parameter


### PR DESCRIPTION
The definitions of the `title` and `text` members of `ShareTargetParams` were swapped; this associates the correct definition with the correct member.

I got here from w3ctag/design-reviews#221.