### PR TITLE
Move name/value pair separator out of <code>.

### DIFF
--- a/index.html
+++ b/index.html
@@ -522,7 +522,7 @@ partial dictionary WebAppManifest {
               </li>
               <li>
                 <a data-cite="!FETCH/#concept-header-list-append">Append</a>
-                <code>Content-Type/</code><var>MIME type</var> to <var>header
+                <code>Content-Type</code>/<var>MIME type</var> to <var>header
                 list</var>.
               </li>
             </ol>


### PR DESCRIPTION
The algorithm for appending to a header list accepts a name/value pair.
It seems like the / separating the pair shouldn't be in the `<code>`
element enclosing the name.

I got here from w3ctag/design-reviews#221.