### PR TITLE
Launch algorithm: Removed manifest URL parameter (not used).

### DIFF
--- a/index.html
+++ b/index.html
@@ -467,8 +467,7 @@ partial dictionary WebAppManifest {
         </h3>
         <p>
           When <a>web share target</a> having <a>WebAppManifest</a>
-          <var>manifest</var> at <a data-cite="!URL#concept-url">URL</a>
-          <var>manifest URL</var> is <a>invoked</a> with <a data-cite=
+          <var>manifest</var> is <a>invoked</a> with <a data-cite=
           "!WebShare#dom-sharedata"><code>ShareData</code></a> <var>data</var>,
           run the following steps:
         </p>


### PR DESCRIPTION
This parameter seems to no longer be used in this algorithm.