### PR TITLE
Potentially trustworthy origins

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,6 +303,11 @@ partial dictionary WebAppManifest {
           <li>If <var>share target</var> is <code>undefined</code>, then return
           <code>undefined</code>.
           </li>
+          <li>If the <a data-cite="!URL#concept-url-origin">origin</a> of <var>
+            manifest URL</var> is not <a data-cite=
+            "!SECURE-CONTEXTS/#is-origin-trustworthy">potentially
+            trustworthy</a>, return <code>undefined</code>.
+          </li>
           <li>If <var>share target</var>["<a data-link-for=
           "ShareTarget">method</a>"] is neither an <a data-cite=
           "!INFRA#ascii-case-insensitive">ASCII case-insensitive</a> match for
@@ -340,6 +345,13 @@ partial dictionary WebAppManifest {
             "ShareTarget">action</a> is outside of the <a data-cite=
             "!appmanifest#dfn-navigation-scope">navigation scope</a> , and
             return <code>undefined</code>.
+          </li>
+          <li>If the <a data-cite="!URL#concept-url-origin">origin</a> of <var>
+            action</var> is not <a data-cite=
+            "!SECURE-CONTEXTS/#is-origin-trustworthy">potentially
+            trustworthy</a>, <a data-cite=
+            "!appmanifest#dfn-issue-a-developer-warning">issue a developer
+            warning</a> and return <code>undefined</code>.
           </li>
           <li>Set <var>share target</var>["<a data-link-for=
           "ShareTarget">action</a>"] to <var>action</var>.

--- a/index.html
+++ b/index.html
@@ -285,12 +285,10 @@ partial dictionary WebAppManifest {
         </p>
         <p>
           A <dfn data-lt="web share targets">web share target</dfn> is a web
-          site in a <a data-cite="!SECURE-CONTEXTS#secure-context">secure
-          context</a> with a valid manifest containing a <a>share_target</a>
-          member. A web share target is a type of <a data-cite=
+          site with a valid manifest containing a <a>share_target</a> member. A
+          web share target is a type of <a data-cite=
           "!WebShare#dfn-share-target">share target</a>.
         </p>
-        <div class="issue" data-number="27"></div>
         <p>
           The steps for <dfn>post-processing the <code>share_target</code>
           member</dfn> is given by the following algorithm. The algorithm takes
@@ -302,11 +300,6 @@ partial dictionary WebAppManifest {
         <ol>
           <li>If <var>share target</var> is <code>undefined</code>, then return
           <code>undefined</code>.
-          </li>
-          <li>If the <a data-cite="!URL#concept-url-origin">origin</a> of <var>
-            manifest URL</var> is not <a data-cite=
-            "!SECURE-CONTEXTS/#is-origin-trustworthy">potentially
-            trustworthy</a>, return <code>undefined</code>.
           </li>
           <li>If <var>share target</var>["<a data-link-for=
           "ShareTarget">method</a>"] is neither an <a data-cite=
@@ -674,10 +667,11 @@ partial dictionary WebAppManifest {
         from an online index, rather than a set of targets that the end user
         has explicitly installed or registered.
         </li>
-        <li>The requirement that the web share target be a <a data-cite=
-        "SECURE-CONTEXTS#secure-context">secure context</a> is to prevent
-        private user data from being transmitted to a party that does not
-        control the origin in question, or in clear text over the network.
+        <li>The requirement that the web share target's origin be
+          <a data-cite="!SECURE-CONTEXTS/#is-origin-trustworthy">potentially
+          trustworthy</a> is to prevent private user data from being
+          transmitted to a party that does not control the origin in question,
+          or in clear text over the network.
         </li>
       </ul>
     </section>

--- a/index.html
+++ b/index.html
@@ -668,7 +668,7 @@ partial dictionary WebAppManifest {
         has explicitly installed or registered.
         </li>
         <li>The requirement that the web share target's origin be
-          <a data-cite="!SECURE-CONTEXTS/#is-origin-trustworthy">potentially
+          <a data-cite="SECURE-CONTEXTS/#is-origin-trustworthy">potentially
           trustworthy</a> is to prevent private user data from being
           transmitted to a party that does not control the origin in question,
           or in clear text over the network.


### PR DESCRIPTION
The manifest and action urls must be "potentially trustworthy"
e.g. https or 127.0.0.1

We may not need to refer to "secure contexts" - see #27


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ewilligers/web-share-target/pull/69.html" title="Last updated on Aug 30, 2018, 1:36 PM GMT (42a39ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-share-target/69/3fccfd1...ewilligers:42a39ba.html" title="Last updated on Aug 30, 2018, 1:36 PM GMT (42a39ba)">Diff</a>