### PR TITLE
Validate enctype when method is GET

### DIFF
--- a/level-2/index.html
+++ b/level-2/index.html
@@ -358,6 +358,18 @@ partial dictionary WebAppManifest {
           <li>If <var>share target</var>["<a data-link-for=
           "ShareTarget">method</a>"] is an <a data-cite=
           "!INFRA#ascii-case-insensitive">ASCII case-insensitive</a> match for
+          the string <code>"GET"</code> and <var>share
+          target</var>["<a data-link-for="ShareTarget">enctype</a>"] is not an
+          <a data-cite="!INFRA#ascii-case-insensitive">ASCII
+          case-insensitive</a> match for the string
+          <code>"application/x-www-form-urlencoded"</code>, <a data-cite=
+          "!appmanifest#dfn-issue-a-developer-warning">issue a developer
+          warning</a> that the enctype is not supported with method GET, and
+          return <code>undefined</code>.
+          </li>
+          <li>If <var>share target</var>["<a data-link-for=
+          "ShareTarget">method</a>"] is an <a data-cite=
+          "!INFRA#ascii-case-insensitive">ASCII case-insensitive</a> match for
           the string <code>"POST"</code> and <var>share
           target</var>["<a data-link-for="ShareTarget">enctype</a>"] is neither
           an <a data-cite="!INFRA#ascii-case-insensitive">ASCII
@@ -488,8 +500,7 @@ partial dictionary WebAppManifest {
         </p>
         <p>
           The <dfn>enctype</dfn> member specifies how the share data is encoded
-          in the body of a <code>POST</code> request. It is ignored when
-          <a>method</a> is <code>"GET"</code>.
+          in the request.
         </p>
         <p>
           The <dfn>params</dfn> member contains a <a>ShareTargetParams</a>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ewilligers/web-share-target/pull/72.html" title="Last updated on Nov 5, 2018, 11:04 PM GMT (2867ec2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-share-target/72/76eabad...ewilligers:2867ec2.html" title="Last updated on Nov 5, 2018, 11:04 PM GMT (2867ec2)">Diff</a>