### PR TITLE
Skip bad files entries and make accept required

### DIFF
--- a/level-2/index.html
+++ b/level-2/index.html
@@ -283,7 +283,7 @@ self.addEventListener('fetch', event =&gt; {
       <pre class="idl">
 dictionary ShareTargetFiles {
   required USVString name;
-  (USVString or sequence&lt;USVString&gt;) accept;
+  required (USVString or sequence&lt;USVString&gt;) accept;
 };
 
 dictionary ShareTargetParams {
@@ -386,7 +386,7 @@ partial dictionary WebAppManifest {
           dictionary, <var>bucket</var>, set <var>share
           target</var>["<a data-link-for=
           "ShareTarget">params</a>"]["<a data-link-for=
-          "ShareTargetParams">files</a>"] to [<var>bucket</var>].
+          "ShareTargetParams">files</a>"] to «<var>bucket</var>».
           </li>
           <li>If <var>share target</var>["<a data-link-for=
           "ShareTarget">params</a>"]["<a data-link-for=
@@ -421,7 +421,7 @@ partial dictionary WebAppManifest {
               "ShareTargetFiles">accept</a>"] is a <a data-cite=
               "!WEBIDL#idl-USVString">USVString</a>, <var>accept</var>, set
               <var>bucket</var>["<a data-link-for=
-              "ShareTargetFiles">accept</a>"] to [<var>accept</var>].
+              "ShareTargetFiles">accept</a>"] to «<var>accept</var>».
               </li>
               <li>For each string in <var>bucket</var>["<a data-link-for=
               "ShareTargetFiles">accept</a>"] that does not match any of the

--- a/level-2/index.html
+++ b/level-2/index.html
@@ -409,11 +409,6 @@ partial dictionary WebAppManifest {
           "ShareTargetParams">files</a>"]:
             <ol>
               <li>If <var>bucket</var>["<a data-link-for=
-              "ShareTargetFiles">name</a>"] is an empty string, <a data-cite=
-              "!appmanifest#dfn-issue-a-developer-warning">issue a developer
-              warning</a> and return <code>undefined</code>.
-              </li>
-              <li>If <var>bucket</var>["<a data-link-for=
               "ShareTargetFiles">accept</a>"] is a <a data-cite=
               "!WEBIDL#idl-USVString">USVString</a>, <var>accept</var>, set
               <var>bucket</var>["<a data-link-for=
@@ -421,9 +416,9 @@ partial dictionary WebAppManifest {
               </li>
               <li>If <var>bucket</var>["<a data-link-for=
               "ShareTargetFiles">accept</a>"] contains a string that does not
-              match any of the following, <a data-cite=
-              "!appmanifest#dfn-issue-a-developer-warning">issue a developer
-              warning</a> and return <code>undefined</code>.
+              match any of the following, set
+              <var>bucket</var>["<a data-link-for="ShareTargetFiles">name</a>"]
+              to an empty string.
                 <ul>
                   <li>a string whose first character is a U+002E FULL STOP
                   character (.)
@@ -443,6 +438,12 @@ partial dictionary WebAppManifest {
                 </ul>
               </li>
             </ol>
+          </li>
+          <li>Remove from <var>share target</var>["<a data-link-for=
+          "ShareTarget">params</a>"]["<a data-link-for=
+          "ShareTargetParams">files</a>"] any <a>ShareTargetFiles</a>
+          <var>bucket</var> where <var>bucket</var>["<a data-link-for=
+          "ShareTargetFiles">name</a>"] is an empty string.
           </li>
           <li>Let <var>action</var> be the result of <a data-cite=
           "!URL#concept-url-parser">parsing</a> the <a data-cite=

--- a/level-2/index.html
+++ b/level-2/index.html
@@ -283,7 +283,7 @@ self.addEventListener('fetch', event =&gt; {
       <pre class="idl">
 dictionary ShareTargetFiles {
   required USVString name;
-  (USVString or sequence&lt;USVString&gt;) accept = [];
+  (USVString or sequence&lt;USVString&gt;) accept;
 };
 
 dictionary ShareTargetParams {
@@ -423,15 +423,13 @@ partial dictionary WebAppManifest {
               <var>bucket</var>["<a data-link-for=
               "ShareTargetFiles">accept</a>"] to [<var>accept</var>].
               </li>
-              <li>If <var>bucket</var>["<a data-link-for=
-              "ShareTargetFiles">accept</a>"] contains a string that does not
-              match any of the following, <a data-cite=
+              <li>For each string in <var>bucket</var>["<a data-link-for=
+              "ShareTargetFiles">accept</a>"] that does not match any of the
+              following, <a data-cite=
               "!appmanifest#dfn-issue-a-developer-warning">issue a developer
-              warning</a>, remove <var>bucket</var> from <var>share
-              target</var>["<a data-link-for=
-              "ShareTarget">params</a>"]["<a data-link-for=
-              "ShareTargetParams">files</a>"] and <a data-cite=
-              "!INFRA#iteration-continue">continue</a>.
+              warning</a> and remove the string from
+              <var>bucket</var>["<a data-link-for=
+              "ShareTargetFiles">accept</a>"].
                 <ul>
                   <li>a string whose first character is a U+002E FULL STOP
                   character (.)
@@ -449,6 +447,14 @@ partial dictionary WebAppManifest {
                     <code>*/*</code>
                   </li>
                 </ul>
+              </li>
+              <li>If <var>bucket</var>["<a data-link-for=
+              "ShareTargetFiles">accept</a>"] is empty, <a data-cite=
+              "!appmanifest#dfn-issue-a-developer-warning">issue a developer
+              warning</a> and remove <var>bucket</var> from <var>share
+              target</var>["<a data-link-for=
+              "ShareTarget">params</a>"]["<a data-link-for=
+              "ShareTargetParams">files</a>"].
               </li>
             </ol>
           </li>
@@ -558,8 +564,7 @@ partial dictionary WebAppManifest {
         <p>
           The <dfn>accept</dfn> member specifies a sequence of accepted MIME
           type(s) or file extension(s), the latter expressed as strings
-          starting with U+002E FULL STOP (.). An empty sequence indicates that
-          all files are accepted.
+          starting with U+002E FULL STOP (.).
         </p>
       </section>
     </section>
@@ -883,9 +888,6 @@ partial dictionary WebAppManifest {
           is as follows:-
         </p>
         <ol>
-          <li>If <var>bucket</var>["<a data-link-for=
-          "ShareTargetFiles">accept</a>"] is empty, return <code>true</code>.
-          </li>
           <li>For each <var>criterion</var> in
           <var>bucket</var>["<a data-link-for="ShareTargetFiles">accept</a>"]:
             <ol>

--- a/level-2/index.html
+++ b/level-2/index.html
@@ -409,6 +409,15 @@ partial dictionary WebAppManifest {
           "ShareTargetParams">files</a>"]:
             <ol>
               <li>If <var>bucket</var>["<a data-link-for=
+              "ShareTargetFiles">name</a>"] is an empty string, <a data-cite=
+              "!appmanifest#dfn-issue-a-developer-warning">issue a developer
+              warning</a>, remove <var>bucket</var> from <var>share
+              target</var>["<a data-link-for=
+              "ShareTarget">params</a>"]["<a data-link-for=
+              "ShareTargetParams">files</a>"] and <a data-cite=
+              "!INFRA#iteration-continue">continue</a>.
+              </li>
+              <li>If <var>bucket</var>["<a data-link-for=
               "ShareTargetFiles">accept</a>"] is a <a data-cite=
               "!WEBIDL#idl-USVString">USVString</a>, <var>accept</var>, set
               <var>bucket</var>["<a data-link-for=
@@ -416,9 +425,13 @@ partial dictionary WebAppManifest {
               </li>
               <li>If <var>bucket</var>["<a data-link-for=
               "ShareTargetFiles">accept</a>"] contains a string that does not
-              match any of the following, set
-              <var>bucket</var>["<a data-link-for="ShareTargetFiles">name</a>"]
-              to an empty string.
+              match any of the following, <a data-cite=
+              "!appmanifest#dfn-issue-a-developer-warning">issue a developer
+              warning</a>, remove <var>bucket</var> from <var>share
+              target</var>["<a data-link-for=
+              "ShareTarget">params</a>"]["<a data-link-for=
+              "ShareTargetParams">files</a>"] and <a data-cite=
+              "!INFRA#iteration-continue">continue</a>.
                 <ul>
                   <li>a string whose first character is a U+002E FULL STOP
                   character (.)
@@ -438,12 +451,6 @@ partial dictionary WebAppManifest {
                 </ul>
               </li>
             </ol>
-          </li>
-          <li>Remove from <var>share target</var>["<a data-link-for=
-          "ShareTarget">params</a>"]["<a data-link-for=
-          "ShareTargetParams">files</a>"] any <a>ShareTargetFiles</a>
-          <var>bucket</var> where <var>bucket</var>["<a data-link-for=
-          "ShareTargetFiles">name</a>"] is an empty string.
           </li>
           <li>Let <var>action</var> be the result of <a data-cite=
           "!URL#concept-url-parser">parsing</a> the <a data-cite=


### PR DESCRIPTION
If the name is an empty string, discard that files entry instead
of rejecting the entire share target.

If an accept entry is invalid, discard that accept entry instead
of rejecting either the files entry or the entire share target.

If accept is an empty array (either initially or because it only
contained invalid entries), discard the files entry.

Note an an empty accept array previously had the opposite
meaning, i.e. that the files entry accepted all files.

resolves #77


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ewilligers/web-share-target/pull/78.html" title="Last updated on Dec 17, 2018, 7:35 AM UTC (f133b17)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-share-target/78/4078bc4...ewilligers:f133b17.html" title="Last updated on Dec 17, 2018, 7:35 AM UTC (f133b17)">Diff</a>